### PR TITLE
Add opt-in NuGet and Docker layer caching to dotnet CI reusable workflows

### DIFF
--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -29,11 +29,6 @@ on:
         required: false
         default: 'container-image'
         type: string
-      enableDockerCache:
-        description: Enable Docker BuildKit layer caching via GitHub Actions cache
-        required: false
-        type: boolean
-        default: false
       nugetConfigPath:
         description: Directory containing NuGet.Config relative to repo root, mounted as a BuildKit secret during dotnet restore. Leave empty if no private NuGet feeds are needed.
         required: false
@@ -46,7 +41,6 @@ on:
         description: GHA cache scope for Docker layer caching. Use a unique value per service to avoid cache thrashing.
         required: false
         type: string
-        default: 'buildkit'
     secrets:
       NPMRC_CONFIG:
         required: false
@@ -111,8 +105,8 @@ jobs:
           tags: ${{ inputs.repositoryName }}:tmp
           build-args: ${{ inputs.dockerBuildArguments }}
           load: true
-          cache-from: ${{ inputs.enableDockerCache && format('type=gha,scope={0}', inputs.dockerCacheScope) || '' }}
-          cache-to: ${{ inputs.enableDockerCache && format('type=gha,scope={0},mode=max', inputs.dockerCacheScope) || '' }}
+          cache-from: ${{ inputs.dockerCacheScope != '' && format('type=gha,scope={0}', inputs.dockerCacheScope) || '' }}
+          cache-to: ${{ inputs.dockerCacheScope != '' && format('type=gha,scope={0},mode=max', inputs.dockerCacheScope) || '' }}
           secret-files: |
             nuget_config=./.nuget-config-for-docker
           secrets: |

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: "container-image"
         type: string
+      enableDockerCache:
+        description: Enable Docker BuildKit layer caching via GitHub Actions cache
+        required: false
+        type: boolean
+        default: false
     secrets:
       NUGET_CONFIG:
         required: false
@@ -81,6 +86,8 @@ jobs:
           tags: ${{ inputs.repositoryName }}:tmp
           build-args: ${{ inputs.dockerBuildArguments }}
           load: true
+          cache-from: ${{ inputs.enableDockerCache && 'type=gha' || '' }}
+          cache-to: ${{ inputs.enableDockerCache && 'type=gha,mode=max' || '' }}
           secrets: |
             nuget_config=${{ secrets.NUGET_CONFIG }}
             npmrc_config=${{ secrets.NPMRC_CONFIG }}

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -5,29 +5,29 @@ on:
     inputs:
       vmImage:
         type: string
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         required: false
       dockerFile:
         required: true
         type: string
       dockerBuildContext:
         required: false
-        default: "."
+        default: '.'
         type: string
       dockerBuildArguments:
         required: false
-        default: ""
+        default: ''
         type: string
       repositoryName:
         required: true
         type: string
       gitRepo:
         required: false
-        default: ""
+        default: ''
         type: string
       artifactName:
         required: false
-        default: "container-image"
+        default: 'container-image'
         type: string
       enableDockerCache:
         description: Enable Docker BuildKit layer caching via GitHub Actions cache
@@ -38,10 +38,19 @@ on:
         description: Directory containing NuGet.Config relative to repo root, mounted as a BuildKit secret during dotnet restore. Leave empty if no private NuGet feeds are needed.
         required: false
         type: string
+      sparseCheckout:
+        description: Newline-separated list of paths for sparse checkout. Leave empty for full checkout.
+        required: false
+        type: string
+      dockerCacheScope:
+        description: GHA cache scope for Docker layer caching. Use a unique value per service to avoid cache thrashing.
+        required: false
+        type: string
+        default: 'buildkit'
     secrets:
       NPMRC_CONFIG:
         required: false
-        description: "Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)"
+        description: 'Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)'
 
 jobs:
   docker-build-and-save:
@@ -50,14 +59,17 @@ jobs:
     steps:
       - name: Conditional Checkout
         if: ${{ inputs.gitRepo != '' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.gitRepo }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Default Checkout
         if: ${{ inputs.gitRepo == '' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Replace GitHub Packages feed token in NuGet.Config files
         shell: pwsh
@@ -99,8 +111,8 @@ jobs:
           tags: ${{ inputs.repositoryName }}:tmp
           build-args: ${{ inputs.dockerBuildArguments }}
           load: true
-          cache-from: ${{ inputs.enableDockerCache && 'type=gha' || '' }}
-          cache-to: ${{ inputs.enableDockerCache && 'type=gha,mode=max' || '' }}
+          cache-from: ${{ inputs.enableDockerCache && format('type=gha,scope={0}', inputs.dockerCacheScope) || '' }}
+          cache-to: ${{ inputs.enableDockerCache && format('type=gha,scope={0},mode=max', inputs.dockerCacheScope) || '' }}
           secret-files: |
             nuget_config=./.nuget-config-for-docker
           secrets: |

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -88,8 +88,9 @@ jobs:
           load: true
           cache-from: ${{ inputs.enableDockerCache && 'type=gha' || '' }}
           cache-to: ${{ inputs.enableDockerCache && 'type=gha,mode=max' || '' }}
+          secret-files: |
+            nuget_config=./NuGet.Config
           secrets: |
-            nuget_config=${{ secrets.NUGET_CONFIG }}
             npmrc_config=${{ secrets.NPMRC_CONFIG }}
 
       - name: Save Docker Image

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -92,13 +92,13 @@ jobs:
           }
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.dockerBuildContext }}
           file: ${{ inputs.dockerFile }}

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -34,10 +34,11 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      NUGET_CONFIG:
+      nugetConfigPath:
+        description: Path to NuGet.Config relative to repo root, mounted as a BuildKit secret during dotnet restore. Leave empty if no private NuGet feeds are needed.
         required: false
-        description: "Full NuGet.Config content for private package sources (mounted as BuildKit secret during restore only)"
+        type: string
+    secrets:
       NPMRC_CONFIG:
         required: false
         description: "Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)"
@@ -72,6 +73,17 @@ jobs:
               }
           }
 
+      - name: Prepare NuGet.Config for Docker secret mount
+        shell: pwsh
+        run: |
+          if ("${{ inputs.nugetConfigPath }}" -eq "") {
+            '<?xml version="1.0" encoding="utf-8"?><configuration></configuration>' | Set-Content ./.nuget-config-for-docker
+          } elseif (Test-Path "${{ inputs.nugetConfigPath }}") {
+            Copy-Item "${{ inputs.nugetConfigPath }}" ./.nuget-config-for-docker
+          } else {
+            Write-Error "nugetConfigPath '${{ inputs.nugetConfigPath }}' not found. Set to empty string if no private feeds are needed."
+          }
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -89,7 +101,7 @@ jobs:
           cache-from: ${{ inputs.enableDockerCache && 'type=gha' || '' }}
           cache-to: ${{ inputs.enableDockerCache && 'type=gha,mode=max' || '' }}
           secret-files: |
-            nuget_config=./NuGet.Config
+            nuget_config=./.nuget-config-for-docker
           secrets: |
             npmrc_config=${{ secrets.NPMRC_CONFIG }}
 

--- a/.github/workflows/docker-build-and-save.yml
+++ b/.github/workflows/docker-build-and-save.yml
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: false
       nugetConfigPath:
-        description: Path to NuGet.Config relative to repo root, mounted as a BuildKit secret during dotnet restore. Leave empty if no private NuGet feeds are needed.
+        description: Directory containing NuGet.Config relative to repo root, mounted as a BuildKit secret during dotnet restore. Leave empty if no private NuGet feeds are needed.
         required: false
         type: string
     secrets:
@@ -76,12 +76,13 @@ jobs:
       - name: Prepare NuGet.Config for Docker secret mount
         shell: pwsh
         run: |
-          if ("${{ inputs.nugetConfigPath }}" -eq "") {
+          $configDir = "${{ inputs.nugetConfigPath }}"
+          if ($configDir -eq "") {
             '<?xml version="1.0" encoding="utf-8"?><configuration></configuration>' | Set-Content ./.nuget-config-for-docker
-          } elseif (Test-Path "${{ inputs.nugetConfigPath }}") {
-            Copy-Item "${{ inputs.nugetConfigPath }}" ./.nuget-config-for-docker
+          } elseif (Test-Path "$configDir/NuGet.Config") {
+            Copy-Item "$configDir/NuGet.Config" ./.nuget-config-for-docker
           } else {
-            Write-Error "nugetConfigPath '${{ inputs.nugetConfigPath }}' not found. Set to empty string if no private feeds are needed."
+            Write-Error "NuGet.Config not found in '$configDir'. Set nugetConfigPath to empty string if no private feeds are needed."
           }
 
       - name: Set up QEMU

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -57,6 +57,21 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      enableNugetCache:
+        description: Enable NuGet package caching to speed up restores
+        required: false
+        type: boolean
+        default: false
+      nugetCacheDependencyPath:
+        description: Glob pattern for lock files used as cache key (scoped to relevant solution)
+        required: false
+        type: string
+        default: ""
+      enableDockerCache:
+        description: Enable Docker BuildKit layer caching via GitHub Actions cache
+        required: false
+        type: boolean
+        default: false
     secrets:
       NUGET_CONFIG:
         required: false
@@ -76,6 +91,8 @@ jobs:
       dotnetVersion: ${{ inputs.dotnetVersion }}
       azureServicePrincipalClientId: ${{ inputs.azureServicePrincipalClientId }}
       azureTenantId: ${{ inputs.azureTenantId }}
+      enableNugetCache: ${{ inputs.enableNugetCache }}
+      nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
 
   create_migration_bundle:
     if: ${{ inputs.migrationBundleArguments != '' }}
@@ -87,7 +104,9 @@ jobs:
       migrationBundleAppSettingsPath: ${{ inputs.migrationBundleAppSettingsPath }}
       dotnetVersion: ${{ inputs.dotnetVersion }}
       ostype: ${{ inputs.ostype }}
-      
+      enableNugetCache: ${{ inputs.enableNugetCache }}
+      nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
+
   build_docker_image:
     needs: [test, create_migration_bundle]
     if: ${{ always() && inputs.dockerFile != '' && (needs.test.result == 'success' || needs.test.result == 'skipped') && (needs.create_migration_bundle.result == 'success' || needs.create_migration_bundle.result == 'skipped') }}
@@ -102,3 +121,4 @@ jobs:
       dockerFile: ${{ inputs.dockerFile }}
       repositoryName: ${{ inputs.repositoryName }}
       dockerBuildArguments: ${{ inputs.dockerBuildArguments }}
+      enableDockerCache: ${{ inputs.enableDockerCache }}

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -47,11 +47,9 @@ on:
       azureServicePrincipalClientId:
         required: false
         type: string
-        default: ""
       azureTenantId:
         required: false
         type: string
-        default: ""
       ostype:
         description: Operating system type for the migrations bundle runtime
         required: false
@@ -61,7 +59,6 @@ on:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
-        default: ""
       enableDockerCache:
         description: Enable Docker BuildKit layer caching via GitHub Actions cache
         required: false

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -59,11 +59,6 @@ on:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
-      enableDockerCache:
-        description: Enable Docker BuildKit layer caching via GitHub Actions cache
-        required: false
-        type: boolean
-        default: false
       sparseCheckout:
         description: Newline-separated list of paths for sparse checkout. Leave empty for full checkout.
         required: false
@@ -72,7 +67,6 @@ on:
         description: GHA cache scope for Docker layer caching. Use a unique value per service to avoid cache thrashing.
         required: false
         type: string
-        default: 'buildkit'
     secrets:
       NPMRC_CONFIG:
         required: false
@@ -118,7 +112,6 @@ jobs:
       dockerFile: ${{ inputs.dockerFile }}
       repositoryName: ${{ inputs.repositoryName }}
       dockerBuildArguments: ${{ inputs.dockerBuildArguments }}
-      enableDockerCache: ${{ inputs.enableDockerCache }}
       nugetConfigPath: ${{ inputs.nugetConfigPath }}
       sparseCheckout: ${{ inputs.sparseCheckout }}
       dockerCacheScope: ${{ inputs.dockerCacheScope }}

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -68,9 +68,6 @@ on:
         type: boolean
         default: false
     secrets:
-      NUGET_CONFIG:
-        required: false
-        description: "Full NuGet.Config content for private package sources (mounted as BuildKit secret during Docker restore only)"
       NPMRC_CONFIG:
         required: false
         description: "Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)"
@@ -105,7 +102,6 @@ jobs:
     if: ${{ always() && inputs.dockerFile != '' && (needs.test.result == 'success' || needs.test.result == 'skipped') && (needs.create_migration_bundle.result == 'success' || needs.create_migration_bundle.result == 'skipped') }}
     uses: ./.github/workflows/docker-build-and-save.yml
     secrets:
-      NUGET_CONFIG: ${{ secrets.NUGET_CONFIG }}
       NPMRC_CONFIG: ${{ secrets.NPMRC_CONFIG }}
     with:
       vmImage: ${{ inputs.vmImage }}
@@ -115,3 +111,4 @@ jobs:
       repositoryName: ${{ inputs.repositoryName }}
       dockerBuildArguments: ${{ inputs.dockerBuildArguments }}
       enableDockerCache: ${{ inputs.enableDockerCache }}
+      nugetConfigPath: ${{ inputs.nugetConfigPath }}

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -57,11 +57,6 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      enableNugetCache:
-        description: Enable NuGet package caching to speed up restores
-        required: false
-        type: boolean
-        default: false
       nugetCacheDependencyPath:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
@@ -91,7 +86,6 @@ jobs:
       dotnetVersion: ${{ inputs.dotnetVersion }}
       azureServicePrincipalClientId: ${{ inputs.azureServicePrincipalClientId }}
       azureTenantId: ${{ inputs.azureTenantId }}
-      enableNugetCache: ${{ inputs.enableNugetCache }}
       nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
 
   create_migration_bundle:
@@ -104,7 +98,6 @@ jobs:
       migrationBundleAppSettingsPath: ${{ inputs.migrationBundleAppSettingsPath }}
       dotnetVersion: ${{ inputs.dotnetVersion }}
       ostype: ${{ inputs.ostype }}
-      enableNugetCache: ${{ inputs.enableNugetCache }}
       nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
 
   build_docker_image:

--- a/.github/workflows/dotnet-ci-jobs.yml
+++ b/.github/workflows/dotnet-ci-jobs.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       vmImage:
         type: string
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         required: false
       gitRepo:
         required: false
@@ -20,14 +20,14 @@ on:
         type: string
       dotnetVersion:
         required: false
-        default: "7.*"
+        default: '7.*'
         type: string
       testProjects:
         required: false
         type: string
       dockerBuildContext:
         required: false
-        default: "."
+        default: '.'
         type: string
       dockerFile:
         required: false
@@ -64,10 +64,19 @@ on:
         required: false
         type: boolean
         default: false
+      sparseCheckout:
+        description: Newline-separated list of paths for sparse checkout. Leave empty for full checkout.
+        required: false
+        type: string
+      dockerCacheScope:
+        description: GHA cache scope for Docker layer caching. Use a unique value per service to avoid cache thrashing.
+        required: false
+        type: string
+        default: 'buildkit'
     secrets:
       NPMRC_CONFIG:
         required: false
-        description: "Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)"
+        description: 'Full .npmrc content for private npm registries (mounted as BuildKit secret during npm install only)'
 
 jobs:
   test:
@@ -81,6 +90,7 @@ jobs:
       azureServicePrincipalClientId: ${{ inputs.azureServicePrincipalClientId }}
       azureTenantId: ${{ inputs.azureTenantId }}
       nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
+      sparseCheckout: ${{ inputs.sparseCheckout }}
 
   create_migration_bundle:
     if: ${{ inputs.migrationBundleArguments != '' }}
@@ -93,6 +103,7 @@ jobs:
       dotnetVersion: ${{ inputs.dotnetVersion }}
       ostype: ${{ inputs.ostype }}
       nugetCacheDependencyPath: ${{ inputs.nugetCacheDependencyPath }}
+      sparseCheckout: ${{ inputs.sparseCheckout }}
 
   build_docker_image:
     needs: [test, create_migration_bundle]
@@ -109,3 +120,5 @@ jobs:
       dockerBuildArguments: ${{ inputs.dockerBuildArguments }}
       enableDockerCache: ${{ inputs.enableDockerCache }}
       nugetConfigPath: ${{ inputs.nugetConfigPath }}
+      sparseCheckout: ${{ inputs.sparseCheckout }}
+      dockerCacheScope: ${{ inputs.dockerCacheScope }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -11,15 +11,15 @@ on:
       environment:
         required: false
         type: string
-        default: "integration-test"
+        default: 'integration-test'
       vmImage:
         type: string
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         required: false
       buildConfiguration:
         required: false
         type: string
-        default: "Release"
+        default: 'Release'
       gitRepo:
         required: false
         type: string
@@ -28,7 +28,7 @@ on:
         type: string
       dotnetVersion:
         required: false
-        default: "7.*"
+        default: '7.*'
         type: string
       azureServicePrincipalClientId:
         required: false
@@ -40,6 +40,10 @@ on:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
+      sparseCheckout:
+        description: Newline-separated list of paths for sparse checkout. Leave empty for full checkout.
+        required: false
+        type: string
 jobs:
   test:
     runs-on: ${{ inputs.vmImage }}
@@ -49,13 +53,16 @@ jobs:
     steps:
       - name: Checkout repository
         if: ${{ inputs.gitRepo != '' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.gitRepo }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Default checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Setup dotnet ${{ inputs.dotnetVersion }}
         uses: actions/setup-dotnet@v4
@@ -136,4 +143,4 @@ jobs:
           name: .NET Tests
           path: test-results/*.trx
           reporter: dotnet-trx
-          output-to: "step-summary"
+          output-to: 'step-summary'

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3,7 +3,7 @@ name: .NET Test
 permissions:
   id-token: write
   contents: read
-  packages: read  
+  packages: read
 
 on:
   workflow_call:
@@ -39,6 +39,16 @@ on:
         required: false
         type: string
         default: ""
+      enableNugetCache:
+        description: Enable NuGet package caching to speed up restores
+        required: false
+        type: boolean
+        default: false
+      nugetCacheDependencyPath:
+        description: Glob pattern for lock files used as cache key (scoped to relevant solution)
+        required: false
+        type: string
+        default: ""
 jobs:
   test:
     runs-on: ${{ inputs.vmImage }}
@@ -60,6 +70,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
+          cache: ${{ inputs.enableNugetCache }}
+          cache-dependency-path: ${{ inputs.nugetCacheDependencyPath }}
 
       - name: Azure Login via OIDC
         if: ${{ inputs.azureServicePrincipalClientId != '' && inputs.azureTenantId != '' }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -39,11 +39,6 @@ on:
         required: false
         type: string
         default: ""
-      enableNugetCache:
-        description: Enable NuGet package caching to speed up restores
-        required: false
-        type: boolean
-        default: false
       nugetCacheDependencyPath:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
@@ -70,7 +65,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
-          cache: ${{ inputs.enableNugetCache }}
+          cache: ${{ inputs.nugetCacheDependencyPath != '' }}
           cache-dependency-path: ${{ inputs.nugetCacheDependencyPath }}
 
       - name: Azure Login via OIDC

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -65,7 +65,7 @@ jobs:
           sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Setup dotnet ${{ inputs.dotnetVersion }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
           cache: ${{ inputs.nugetCacheDependencyPath != '' }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Azure Login via OIDC
         if: ${{ inputs.azureServicePrincipalClientId != '' && inputs.azureTenantId != '' }}
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ inputs.azureServicePrincipalClientId }}
           tenant-id: ${{ inputs.azureTenantId }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Report test results
         if: always() && env.present_test_summary == 'true'
-        uses: phoenix-actions/test-reporting@v15
+        uses: phoenix-actions/test-reporting@v16
         with:
           name: .NET Tests
           path: test-results/*.trx

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -60,6 +60,7 @@ jobs:
           sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Default checkout
+        if: ${{ inputs.gitRepo == '' }}
         uses: actions/checkout@v7
         with:
           sparse-checkout: ${{ inputs.sparseCheckout }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -23,7 +23,6 @@ on:
       gitRepo:
         required: false
         type: string
-        default: ""
       testProjects:
         required: true
         type: string
@@ -34,16 +33,13 @@ on:
       azureServicePrincipalClientId:
         required: false
         type: string
-        default: ""
       azureTenantId:
         required: false
         type: string
-        default: ""
       nugetCacheDependencyPath:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
-        default: ""
 jobs:
   test:
     runs-on: ${{ inputs.vmImage }}

--- a/.github/workflows/efcore-migrations-bundle-create.yml
+++ b/.github/workflows/efcore-migrations-bundle-create.yml
@@ -36,11 +36,6 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      enableNugetCache:
-        description: Enable NuGet package caching to speed up restores
-        required: false
-        type: boolean
-        default: false
       nugetCacheDependencyPath:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
@@ -67,7 +62,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
-          cache: ${{ inputs.enableNugetCache }}
+          cache: ${{ inputs.nugetCacheDependencyPath != '' }}
           cache-dependency-path: ${{ inputs.nugetCacheDependencyPath }}
 
       - name: Install EF tools

--- a/.github/workflows/efcore-migrations-bundle-create.yml
+++ b/.github/workflows/efcore-migrations-bundle-create.yml
@@ -7,12 +7,10 @@ on:
         description: Git Repository
         required: false
         type: string
-        default: ""
       nugetConfigPath:
         description: Path to NuGet.Config
         required: false
         type: string
-        default: ""
       migrationBundleArguments:
         description: Arguments for the EF migrations bundle command
         required: true
@@ -40,7 +38,6 @@ on:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
-        default: ""
 
 jobs:
   migrations-bundle-create:

--- a/.github/workflows/efcore-migrations-bundle-create.yml
+++ b/.github/workflows/efcore-migrations-bundle-create.yml
@@ -69,7 +69,7 @@ jobs:
         run: mkdir -p migrations-bundle
 
       - name: Copy NuGet.Config
-        if: ${{ inputs.nugetConfigPath != '' }}
+        if: ${{ inputs.nugetConfigPath != '' && inputs.nugetConfigPath != '.' }}
         run: cp -v ${{ inputs.nugetConfigPath }}/NuGet.Config $GITHUB_WORKSPACE
 
       - name: Replace GitHub Packages feed token in NuGet.Config files

--- a/.github/workflows/efcore-migrations-bundle-create.yml
+++ b/.github/workflows/efcore-migrations-bundle-create.yml
@@ -36,7 +36,16 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-
+      enableNugetCache:
+        description: Enable NuGet package caching to speed up restores
+        required: false
+        type: boolean
+        default: false
+      nugetCacheDependencyPath:
+        description: Glob pattern for lock files used as cache key (scoped to relevant solution)
+        required: false
+        type: string
+        default: ""
 
 jobs:
   migrations-bundle-create:
@@ -58,6 +67,8 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnetVersion }}
+          cache: ${{ inputs.enableNugetCache }}
+          cache-dependency-path: ${{ inputs.nugetCacheDependencyPath }}
 
       - name: Install EF tools
         run: dotnet tool install -g dotnet-ef --version ${{ inputs.dotnetVersion }}

--- a/.github/workflows/efcore-migrations-bundle-create.yml
+++ b/.github/workflows/efcore-migrations-bundle-create.yml
@@ -23,11 +23,11 @@ on:
         description: .NET SDK version to use
         required: true
         type: string
-        default: "7.*"
+        default: '7.*'
       projectName:
         description: Name of the project (used for artifact naming)
         required: false
-        default: "migrations-bundle"
+        default: 'migrations-bundle'
         type: string
       ostype:
         description: Operating system type for the migrations bundle runtime
@@ -38,6 +38,10 @@ on:
         description: Glob pattern for lock files used as cache key (scoped to relevant solution)
         required: false
         type: string
+      sparseCheckout:
+        description: Newline-separated list of paths for sparse checkout. Leave empty for full checkout.
+        required: false
+        type: string
 
 jobs:
   migrations-bundle-create:
@@ -46,14 +50,17 @@ jobs:
     steps:
       - name: Conditional Checkout
         if: ${{ inputs.gitRepo != '' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.gitRepo }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Default Checkout
         if: ${{ inputs.gitRepo == '' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: ${{ inputs.sparseCheckout }}
 
       - name: Setup dotnet ${{ inputs.dotnetVersion }}
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
Fixes #61 

Affected workflows:
  - .github/workflows/docker-build-and-save.yml
  - .github/workflows/dotnet-ci-jobs.yml
  - .github/workflows/dotnet-test.yml
  - .github/workflows/efcore-migrations-bundle-create.yml

Updated used actions to:
  - actions/checkout@v7
  - docker/setup-qemu-action@v4
  - docker/setup-buildx-action@v4
  - docker/build-push-action@v7
  - actions/setup-dotnet@v5
  - phoenix-actions/test-reporting@v16

Changes:
- Add input for sparse checkouts (allows for checking out only a subset of files from repo)
  - Input empty -> No sparse checkout (default) 
- Add input for enabling docker cache (GHA cache backend, max mode)
  - Input empty -> No caching (default) 
- Add input for enabling NuGet-cache (GHA cache backend)
  - Input empty -> No caching (default)  
- Use secret-files input for NuGet.Config docker secret mount
  - Same as regular secrets input, but with path validation (results in warning on failure)